### PR TITLE
added 065

### DIFF
--- a/065.md
+++ b/065.md
@@ -1,0 +1,75 @@
+# 65. 🟡  Upgrade DlnSource
+Date of creation: 14.09.2025
+
+
+#### Upgrade DlnSource up to 1.6.0
+1.6.0 Introduced new method createSaltedOrderForIntent allow to create order without fix fee.
+
+Interact with ProxyAdmin: 0xa7b88a746fa457578d5abd6234471f07d895f46b     
+DlnSource Proxy  0xeF4fB24aD0916217251F553c0596F8Edc630EB66    
+New implementation 0xe13a85137f8752AbE4c5A614Dc3BaF396b00308D      
+```
+ function upgrade(TransparentUpgradeableProxy proxy, address implementation) 
+ proxy: 0xeF4fB24aD0916217251F553c0596F8Edc630EB66
+ implementation: 0xe13a85137f8752AbE4c5A614Dc3BaF396b00308D
+```
+
+data to sign:
+```
+{
+  "to": "0xA7b88A746FA457578D5abd6234471f07D895F46b",
+  "value": "0",
+  "data": "0x99a88ec4000000000000000000000000ef4fb24ad0916217251f553c0596f8edc630eb66000000000000000000000000e13a85137f8752abe4c5a614dc3baf396b00308d",
+  "operation": 0,
+  "baseGas": "0",
+  "gasPrice": "0",
+  "gasToken": "0x0000000000000000000000000000000000000000",
+  "refundReceiver": "0x0000000000000000000000000000000000000000",
+  "nonce": 65,
+  "safeTxGas": "0"
+}
+```
+
+### 🟡 ETH
+[Tenderly](https://dashboard.tenderly.co/public/safe/safe-apps/simulator/076c12c3-41f0-4a50-bc3d-cac69017f200).   
+[Gnosis Safe Tx](https://app.safe.global/transactions/tx?id=multisig_0x6bec1faF33183e1Bc316984202eCc09d46AC92D5_0xb43edfa85ae4c5398ca10f844a9864509d241196d2a7e4a2f574b1858d6f6146&safe=eth:0x6bec1faF33183e1Bc316984202eCc09d46AC92D5).   
+🟡[Executed]()     
+
+### 🟡 BNB
+[Tenderly](https://dashboard.tenderly.co/public/safe/safe-apps/simulator/81db0f37-6dc3-4236-a28d-efc058dfb097).   
+[Gnosis Safe Tx](https://app.safe.global/transactions/tx?id=multisig_0xA52842cD43fA8c4B6660E443194769531d45b265_0xab365f885e93cc64e32392db76b9953f27983d0b9b574b5218f064b4869c0a04&safe=bnb:0xA52842cD43fA8c4B6660E443194769531d45b265).   
+🟡[Executed]()     
+
+
+### 🟡 Polygon
+[Tenderly](https://dashboard.tenderly.co/public/safe/safe-apps/simulator/05708e3b-6ea5-4eca-969a-23df34c4a3c7).   
+[Gnosis Safe Tx]https://app.safe.global/transactions/tx?id=multisig_0xA52842cD43fA8c4B6660E443194769531d45b265_0x909bd51d962da9ab38205cfaa8c71b123de9d180aeec9d44a404ff62d7c99a24&safe=matic:0xA52842cD43fA8c4B6660E443194769531d45b265).   
+🟡[Executed]()     
+
+
+### 🟡 Arbitrum
+[Tenderly](https://dashboard.tenderly.co/public/safe/safe-apps/simulator/a11e88a5-6ead-4e4b-a986-d1e6b0e11f05).   
+[Gnosis Safe Tx](https://app.safe.global/transactions/tx?id=multisig_0xA52842cD43fA8c4B6660E443194769531d45b265_0xcbea89a841f4f82f7d978319de2a2ebe4d8f4caa932e90bbff8feaced13c8319&safe=arb1:0xA52842cD43fA8c4B6660E443194769531d45b265).   
+🟡[Executed]()     
+
+
+### 🟡 Avalanche
+[Tenderly](https://dashboard.tenderly.co/public/safe/safe-apps/simulator/1b557e2f-51d2-406f-bc34-5f0c44b983c0).   
+[Gnosis Safe Tx](https://app.safe.global/transactions/tx?id=multisig_0x8AC842e8f3be6BF67ccfdC87CE3F98D635008Ef0_0x8582f4e91f5587bace141e4d9a4ad58b554d144d225a725ea6eccdd7fbb03078&safe=avax:0x8AC842e8f3be6BF67ccfdC87CE3F98D635008Ef0).   
+🟡[Executed]()     
+
+
+### 🟡 Linea
+[Tenderly](https://dashboard.tenderly.co/public/safe/safe-apps/simulator/e299bb28-246e-4589-b323-6fa10be9061d).   
+[Gnosis Safe Tx](https://app.safe.global/transactions/tx?id=multisig_0xA52842cD43fA8c4B6660E443194769531d45b265_0x6de71fa29e98f8637c96a97d02771b6dcb868246dc10abaaa5c88fd1dbc1c54e&safe=linea:0xA52842cD43fA8c4B6660E443194769531d45b265).   
+🟡[Executed]()     
+
+### 🟡 Base
+[Tenderly](https://dashboard.tenderly.co/public/safe/safe-apps/simulator/58cc9e43-cd41-4894-8141-0563d1c76b30).   
+[Gnosis Safe Tx](https://app.safe.global/transactions/tx?id=multisig_0xF0A9d50F912D64D1105b276526e21881bF48A29e_0xfae53d52d055e0bb3136e8a039f52a18024aa601c454037f00395b41e6bf5733&safe=base:0xF0A9d50F912D64D1105b276526e21881bF48A29e).   
+🟡[Executed]()     
+
+### 🟡 OPTIMISM
+[Tenderly](https://dashboard.tenderly.co/public/safe/safe-apps/simulator/5f6933f4-9a8b-4077-aaad-18b106347afb).   
+[Gnosis Safe Tx](https://app.safe.global/transactions/tx?id=multisig_0xA52842cD43fA8c4B6660E443194769531d45b265_0xa4b2410184fa8cf396a513049c47fe29ffa8fe909a067466b06bf2dea45a3fa3&safe=oeth:0xA52842cD43fA8c4B6660E443194769531d45b265).   
+🟡[Executed]()     

--- a/artifacts/065.json
+++ b/artifacts/065.json
@@ -1,0 +1,40 @@
+{
+    "version": "1.0",
+    "chainId": "1",
+    "createdAt": 1757799503090,
+    "meta": {
+        "name": "Transactions Batch",
+        "description": "",
+        "txBuilderVersion": "1.18.2",
+        "createdFromSafeAddress": "0x6bec1faF33183e1Bc316984202eCc09d46AC92D5",
+        "createdFromOwnerAddress": "",
+        "checksum": "0xb982a6e0763008b0f2b61a16fed0c0ac37804c059c626c48f112ba00651a484a"
+    },
+    "transactions": [
+        {
+            "to": "0xA7b88A746FA457578D5abd6234471f07D895F46b",
+            "value": "0",
+            "data": null,
+            "contractMethod": {
+                "inputs": [
+                    {
+                        "internalType": "contract TransparentUpgradeableProxy",
+                        "name": "proxy",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "implementation",
+                        "type": "address"
+                    }
+                ],
+                "name": "upgrade",
+                "payable": false
+            },
+            "contractInputsValues": {
+                "proxy": "0xeF4fB24aD0916217251F553c0596F8Edc630EB66",
+                "implementation": "0xe13a85137f8752AbE4c5A614Dc3BaF396b00308D"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This PR introduces a proposal to upgrade the `DlnSource` smart contract implementation to `0xe13a85137f8752AbE4c5A614Dc3BaF396b00308D` on the following chains:

1. ethereum
2. bnb
3. polygon
4. arbitrumOne
5. avalanche
6. linea
7. base
8. optimism